### PR TITLE
Release notes highlight only a release is available

### DIFF
--- a/lib/release-notes-status-bar.coffee
+++ b/lib/release-notes-status-bar.coffee
@@ -4,13 +4,27 @@ module.exports =
 class ReleaseNotesStatusBar extends View
   @content: ->
     @div class: 'release-notes-status inline-block', =>
-     @span outlet: 'status', type: 'button', class: 'status icon icon-squirrel'
+     @span outlet: 'status', type: 'button', style: 'display:none', class: 'status icon icon-squirrel'
 
-  initialize: (options={}) ->
-    @status.addClass('update-available') if options.updateVersion
+  initialize: ({@updateVersion}={})->
+    @onlyShowIfNewerUpdate()
 
     @status.on 'click', =>
       rootView.open('atom://release-notes')
 
     rootView.command 'window:update-available', (event, version) =>
-      @status.addClass('update-available')
+      @updateVersion = version
+      @onlyShowIfNewerUpdate()
+
+    atom.config.observe 'release-notes.viewedVersion', (version) =>
+      @onlyShowIfNewerUpdate(version)
+
+  onlyShowIfNewerUpdate: (viewedVersion) ->
+    viewedVersion ?= @getViewedVersion()
+
+    if (@updateVersion and @updateVersion != viewedVersion) or !viewedVersion
+      @status.show()
+    else
+      @status.hide()
+
+  getViewedVersion: -> atom.config.get('release-notes.viewedVersion')

--- a/lib/release-notes-view.coffee
+++ b/lib/release-notes-view.coffee
@@ -61,6 +61,7 @@ class ReleaseNotesView extends View
 
     data = JSON.parse(body)
     latestRelease = @findLatestRelease(data)
+    atom.config.set('release-notes.viewedVersion', latestRelease.tag_name)
     roaster latestRelease.body, (error, contents) =>
       @description.html(contents)
       @description.prepend("<h1>#{latestRelease.tag_name} - #{latestRelease.name}</h1>")

--- a/lib/release-notes.coffee
+++ b/lib/release-notes.coffee
@@ -21,19 +21,19 @@ eachStatusBarRightArea = (callback) ->
       callback(statusBarRight) if statusBarRight.length > 0
     , 10
 
-# Don't serialize this state, as it's only valid until the application restarts
-updateVersion = null
-
 module.exports =
-  activate: (state) ->
-    rootView.on 'window:update-available', (event, version) ->
-      updateVersion = version
+  # Don't serialize this state, as it's only valid until the application restarts
+  updateVersion: null
 
-    rootView.command 'release-notes:show', -> rootView.open('atom://release-notes')
+  activate: (state) ->
+    rootView.on 'window:update-available', (event, version) =>
+      @updateVersion = version
 
     project.registerOpener (filePath) ->
       createReleaseNotesView(uri: releaseNotesUri) if filePath is releaseNotesUri
 
-    eachStatusBarRightArea (statusBarRight) ->
-      releaseNotesStatusBar = new ReleaseNoteStatusBar({updateVersion})
+    rootView.command 'release-notes:show', -> rootView.open('atom://release-notes')
+
+    eachStatusBarRightArea (statusBarRight) =>
+      releaseNotesStatusBar = new ReleaseNoteStatusBar({@updateVersion})
       statusBarRight.append(releaseNotesStatusBar)

--- a/spec/release-notes-status-bar-spec.coffee
+++ b/spec/release-notes-status-bar-spec.coffee
@@ -1,3 +1,4 @@
+{_} = require 'atom'
 ReleaseNotesStatusBar = require '../lib/release-notes-status-bar'
 {RootView} = require 'atom'
 
@@ -6,30 +7,54 @@ describe "ReleaseNotesStatusBar", ->
 
   beforeEach ->
     window.rootView = new RootView
-    atom.activatePackage('status-bar', immediate: true)
-    atom.activatePackage('release-notes', immediate: true)
-    rootView.open('sample.js')
-    advanceClock(10)
+    atom.packages.activatePackage('status-bar', immediate: true)
+    pack = atom.packages.activatePackage('release-notes', immediate: true)
+    pack.mainModule.updateVersion = null
 
-    releaseNotesStatus = rootView.find('.release-notes-status .status')
-    releaseNotesStatusBar = releaseNotesStatus.view()
-
-  describe "with no pending update", ->
-    it "renders without a highlight", ->
-      expect(releaseNotesStatus.hasClass('update-available')).toBeFalsy()
-
-  describe "with a pending update", ->
-    beforeEach -> rootView.trigger 'window:update-available', 'v28.0.0'
-
-    it "renders with a highlight", ->
-      expect(releaseNotesStatus.hasClass('update-available')).toBeTruthy()
-
-  describe "clicking on the status", ->
-    [rootViewOpen] = []
-
+  describe "with no viewed version", ->
     beforeEach ->
-      rootViewOpen = spyOn(rootView, 'open')
-      releaseNotesStatus.trigger('click')
+      rootView.open('sample.js')
+      advanceClock(10)
 
-    it "opens the release notes view", ->
-      expect(rootViewOpen.mostRecentCall.args[0]).toBe 'atom://release-notes'
+      releaseNotesStatus = rootView.find('.release-notes-status .status')
+      releaseNotesStatusBar = releaseNotesStatus.view()
+
+    describe "with no pending update", ->
+      it "renders", ->
+        expect(releaseNotesStatus.is('display')).not.toBe 'none'
+
+    describe "with a pending update", ->
+      beforeEach -> rootView.trigger 'window:update-available', 'v28.0.0'
+
+      it "renders", ->
+        expect(releaseNotesStatus.css('display')).not.toBe 'none'
+
+  describe "with a viewed version", ->
+    beforeEach ->
+      spyOn(atom.config, 'get').andReturn('v27.0.0')
+
+      rootView.open('sample.js')
+      advanceClock(10)
+
+      releaseNotesStatus = rootView.find('.release-notes-status .status')
+      releaseNotesStatusBar = releaseNotesStatus.view()
+
+    describe "with no pending update", ->
+      it "doesn't render", ->
+        expect(releaseNotesStatus.css('display')).toBe 'none'
+
+    describe "with a pending update", ->
+      beforeEach -> rootView.trigger 'window:update-available', 'v28.0.0'
+
+      it "renders", ->
+        expect(releaseNotesStatus.css('display')).not.toBe 'none'
+
+    describe "clicking on the status", ->
+      [rootViewOpen] = []
+
+      beforeEach ->
+        rootViewOpen = spyOn(rootView, 'open')
+        releaseNotesStatus.trigger('click')
+
+      it "opens the release notes view", ->
+        expect(rootViewOpen.mostRecentCall.args[0]).toBe 'atom://release-notes'

--- a/stylesheets/release-notes.less
+++ b/stylesheets/release-notes.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 
 .release-notes-status {
-  .status.update-available {
+  .status {
     color: @background-color-info;
   }
 }


### PR DESCRIPTION
Previously, the release notes icon would always appear so that users could view them whenever. Based on the feedback we've received that's too visible, now the icon only appears when an update is available.

If you'd like to access the current release notes, you can enter `Release Notes:Show` in the command palette.

Fixes #2 
