### PR TITLE
Access the status-bar through the new service API

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -20,9 +20,6 @@ module.exports =
     subscriptions = new CompositeDisposable()
 
     if atom.isReleasedVersion()
-      previousVersion = localStorage.getItem('release-notes:previousVersion')
-      localStorage.setItem('release-notes:previousVersion', atom.getVersion())
-
       subscriptions.add atom.commands.add 'atom-workspace', 'window:update-available', (event) ->
         return unless Array.isArray(event?.detail)
 
@@ -41,14 +38,6 @@ module.exports =
           releaseNotes = []
         createReleaseNotesView(releaseNotesUri, version, releaseNotes)
 
-      createStatusEntry = -> new ReleaseNoteStatusBar(previousVersion)
-
-      if document.querySelector('status-bar')
-        createStatusEntry()
-      else
-        subscriptions.add atom.packages.onDidActivateInitialPackages ->
-          createStatusEntry() if document.querySelector('status-bar')
-
     subscriptions.add atom.commands.add 'atom-workspace', 'release-notes:show', ->
       if atom.isReleasedVersion()
         atom.workspace.open(releaseNotesUri)
@@ -57,3 +46,8 @@ module.exports =
 
   deactivate: ->
     subscriptions.dispose()
+
+  consumeStatusBar: (statusBar) ->
+    previousVersion = localStorage.getItem('release-notes:previousVersion')
+    localStorage.setItem('release-notes:previousVersion', atom.getVersion())
+    new ReleaseNoteStatusBar(statusBar, previousVersion)

--- a/lib/release-notes-status-bar.coffee
+++ b/lib/release-notes-status-bar.coffee
@@ -6,7 +6,7 @@ class ReleaseNotesStatusBar extends View
   @content: ->
     @span type: 'button', class: 'release-notes-status icon icon-squirrel inline-block'
 
-  initialize: (previousVersion) ->
+  initialize: (@statusBar, previousVersion) ->
     @subscriptions = new CompositeDisposable()
 
     @on 'click', -> atom.workspace.open('atom://release-notes')
@@ -16,7 +16,7 @@ class ReleaseNotesStatusBar extends View
     @attach() if previousVersion? and previousVersion isnt atom.getVersion()
 
   attach: ->
-    document.querySelector('status-bar').addRightTile(item: this, priority: -100)
+    @statusBar.addRightTile(item: this, priority: -100)
 
   detached: ->
     @subsriptions?.dispose()

--- a/package.json
+++ b/package.json
@@ -11,5 +11,12 @@
   "dependencies": {
     "roaster": "^1.1.2",
     "space-pen": "^5.0.0"
+  },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^0.58.0": "consumeStatusBar"
+      }
+    }
   }
 }

--- a/spec/release-notes-status-bar-spec.coffee
+++ b/spec/release-notes-status-bar-spec.coffee
@@ -22,11 +22,11 @@ describe "ReleaseNotesStatusBar", ->
       atom.workspace.open('sample.js')
 
   describe "with no update", ->
-    it "does not show view", ->
+    it "does not show the view", ->
       expect(atom.views.getView(atom.workspace)).not.toContain('.release-notes-status')
 
   describe "with an update", ->
-    it "show the view when the update is made available", ->
+    it "shows the view when the update is made available", ->
       triggerUpdate()
       expect(atom.views.getView(atom.workspace)).toContain('.release-notes-status')
 


### PR DESCRIPTION
:warning: This depends on https://github.com/atom/status-bar/pull/51 being merged and released. :warning:

Signed-off-by: Jessica Lord <jlord@github.com>