### PR TITLE
Push top-level require() calls down into the functions that use them.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,5 @@
 {CompositeDisposable} = require 'atom'
 ReleaseNotesView = null
-ReleaseNoteStatusBar = require  './release-notes-status-bar'
 
 releaseNotesUri = 'atom://release-notes'
 
@@ -52,4 +51,5 @@ module.exports =
 
     previousVersion = localStorage.getItem('release-notes:previousVersion')
     localStorage.setItem('release-notes:previousVersion', atom.getVersion())
+    ReleaseNoteStatusBar = require './release-notes-status-bar'
     new ReleaseNoteStatusBar(statusBar, previousVersion)


### PR DESCRIPTION
* `atom.packages.getLoadedPackage('release-notes').loadTime` 1
* `atom.packages.getLoadedPackage('release-notes').activateTime` 2