### PR TITLE
:bug: Fix typo in ::detached

### DIFF
--- a/lib/release-notes-status-bar.coffee
+++ b/lib/release-notes-status-bar.coffee
@@ -19,4 +19,4 @@ class ReleaseNotesStatusBar extends View
     @statusBar.addRightTile(item: this, priority: -100)
 
   detached: ->
-    @subsriptions?.dispose()
+    @subscriptions?.dispose()


### PR DESCRIPTION
Trivial fix for mistyped `@subsriptions` which should have been `@subscriptions`.

/cc @nathansobo @kevinsawicki