### PR TITLE
Add support for scrolling in response to core:page-up and core:page-down

### DIFF
--- a/lib/release-notes-view.coffee
+++ b/lib/release-notes-view.coffee
@@ -1,8 +1,8 @@
-{$$, View} = require 'atom-space-pen-views'
+{$$, ScrollView} = require 'atom-space-pen-views'
 {Disposable} = require 'atom'
 
 module.exports =
-class ReleaseNotesView extends View
+class ReleaseNotesView extends ScrollView
   @content: ->
     @div class: 'release-notes padded pane-item native-key-bindings', tabindex: -1, =>
       @div class: 'block', =>
@@ -31,6 +31,7 @@ class ReleaseNotesView extends View
   onDidChangeModified: -> new Disposable()
 
   initialize: (@uri, @releaseVersion, @releaseNotes) ->
+    super
     @releaseVersion ?= atom.getVersion()
 
     # Support old format

--- a/spec/release-notes-view-spec.coffee
+++ b/spec/release-notes-view-spec.coffee
@@ -89,3 +89,26 @@ describe "ReleaseNotesView", ->
         releaseNotesView = releaseNotes.view()
         expect(releaseNotes.find('h1').text()).toBe '0.3.0'
         expect(releaseNotes.find('.description').text()).toContain "a release"
+
+    describe "when scrolling with core:page-up and core:page-down", ->
+      releaseNotesView = null
+      beforeEach ->
+        spyOn($, 'ajax').andCallFake ({success}) -> success([{tag_name: 'v0.3.0', body: 'a release'}])
+        atom.commands.dispatch(atom.views.getView(atom.workspace), 'window:update-available', ['0.3.0'])
+
+        waitsForPromise ->
+          atom.workspace.open('atom://release-notes')
+
+        runs ->
+          releaseNotes = $(atom.views.getView(atom.workspace)).find('.release-notes')
+          releaseNotesView = releaseNotes.view()
+
+      it "handles core:page-down", ->
+          spyOn(releaseNotesView, 'pageDown')
+          atom.commands.dispatch(releaseNotesView.element, 'core:page-down')
+          expect(releaseNotesView.pageDown).toHaveBeenCalled()
+
+      it "handles core:page-up", ->
+          spyOn(releaseNotesView, 'pageUp')
+          atom.commands.dispatch(releaseNotesView.element, 'core:page-up')
+          expect(releaseNotesView.pageUp).toHaveBeenCalled()


### PR DESCRIPTION
PgUp and PgDn keys weren't scrolling the release notes. This fixes that. I also added new tests to the spec.
