### PR TITLE
Post upgrade, makes the squirrel icon gray

### DIFF
--- a/lib/release-notes-status-bar.coffee
+++ b/lib/release-notes-status-bar.coffee
@@ -4,9 +4,14 @@
 module.exports =
 class ReleaseNotesStatusBar extends View
   @content: ->
-    @span type: 'button', class: 'release-notes-status icon icon-squirrel inline-block'
+    # 'blank' top level span due to issue #58
+    @span =>
+      @span type: 'button', class: 'release-notes-status icon icon-squirrel inline-block', outlet: 'statusIcon'
 
   initialize: (@statusBar, previousVersion) ->
+    if previousVersion? and previousVersion is atom.getVersion()
+      @statusIcon.addClass 'release-notes-status-available'
+
     @subscriptions = new CompositeDisposable()
 
     @on 'click', -> atom.workspace.open('atom://release-notes')

--- a/lib/release-notes-status-bar.coffee
+++ b/lib/release-notes-status-bar.coffee
@@ -7,18 +7,20 @@ class ReleaseNotesStatusBar extends View
     @span type: 'button', class: 'release-notes-status icon icon-squirrel inline-block'
 
   initialize: (@statusBar, previousVersion) ->
-    if previousVersion? and previousVersion is atom.getVersion()
-      @addClass 'release-notes-status-available'
-
     @subscriptions = new CompositeDisposable()
 
     @on 'click', -> atom.workspace.open('atom://release-notes')
-    @subscriptions.add atom.commands.add 'atom-workspace', 'window:update-available', => @attach()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'window:update-available', (event) => @attach(event)
 
     @subscriptions.add atom.tooltips.add(@element, title: 'Click to view the release notes')
     @attach() if previousVersion? and previousVersion isnt atom.getVersion()
 
-  attach: ->
+  attach: (event) ->
+    if Array.isArray(event?.detail)
+      [version] = event.detail
+      if version isnt ('v' + atom.getVersion())
+        @addClass 'release-notes-status-available'
+
     @statusBar.addRightTile(item: this, priority: -100)
 
   detached: ->

--- a/lib/release-notes-status-bar.coffee
+++ b/lib/release-notes-status-bar.coffee
@@ -4,13 +4,11 @@
 module.exports =
 class ReleaseNotesStatusBar extends View
   @content: ->
-    # 'blank' top level span due to issue #58
-    @span =>
-      @span type: 'button', class: 'release-notes-status icon icon-squirrel inline-block', outlet: 'statusIcon'
+    @span type: 'button', class: 'release-notes-status icon icon-squirrel inline-block'
 
   initialize: (@statusBar, previousVersion) ->
     if previousVersion? and previousVersion is atom.getVersion()
-      @statusIcon.addClass 'release-notes-status-available'
+      @addClass 'release-notes-status-available'
 
     @subscriptions = new CompositeDisposable()
 

--- a/lib/release-notes-status-bar.coffee
+++ b/lib/release-notes-status-bar.coffee
@@ -18,7 +18,7 @@ class ReleaseNotesStatusBar extends View
   attach: (event) ->
     if Array.isArray(event?.detail)
       [version] = event.detail
-      if version isnt ('v' + atom.getVersion())
+      if version isnt ("v#{atom.getVersion()}")
         @addClass 'release-notes-status-available'
 
     @statusBar.addRightTile(item: this, priority: -100)

--- a/spec/release-notes-status-bar-spec.coffee
+++ b/spec/release-notes-status-bar-spec.coffee
@@ -29,6 +29,7 @@ describe "ReleaseNotesStatusBar", ->
     it "shows the view when the update is made available", ->
       triggerUpdate()
       expect(atom.views.getView(atom.workspace)).toContain('.release-notes-status')
+      expect(atom.views.getView(atom.workspace)).toContain('.release-notes-status-available')
 
     describe "clicking on the status", ->
       it "opens the release notes view", ->
@@ -36,3 +37,9 @@ describe "ReleaseNotesStatusBar", ->
         triggerUpdate()
         $(atom.views.getView(atom.workspace)).find('.release-notes-status').trigger('click')
         expect(workspaceOpen.mostRecentCall.args[0]).toBe 'atom://release-notes'
+
+  describe "after an update", ->
+    it "shows the view after an update has been downloaded", ->
+      triggerUpdate()
+      expect(atom.views.getView(atom.workspace)).toContain('.release-notes-status')
+      expect(atom.views.getView(atom.workspace)).not.toContain('.release-notes-status-available')

--- a/spec/release-notes-status-bar-spec.coffee
+++ b/spec/release-notes-status-bar-spec.coffee
@@ -3,6 +3,9 @@
 triggerUpdate = ->
   atom.commands.dispatch(atom.views.getView(atom.workspace), 'window:update-available', ['v22.0.0'])
 
+triggerPostUpdate = ->
+  atom.commands.dispatch(atom.views.getView(atom.workspace), 'window:update-available', ['v' + atom.getVersion()])
+
 describe "ReleaseNotesStatusBar", ->
   beforeEach ->
     spyOn(atom, 'isReleasedVersion').andReturn(true)
@@ -40,6 +43,6 @@ describe "ReleaseNotesStatusBar", ->
 
   describe "after an update", ->
     it "shows the view after an update has been downloaded", ->
-      triggerUpdate()
+      triggerPostUpdate()
       expect(atom.views.getView(atom.workspace)).toContain('.release-notes-status')
       expect(atom.views.getView(atom.workspace)).not.toContain('.release-notes-status-available')

--- a/styles/release-notes.less
+++ b/styles/release-notes.less
@@ -1,6 +1,6 @@
 @import "ui-variables";
 
-.release-notes-status {
+.release-notes-status-available {
   color: @background-color-info;
 }
 


### PR DESCRIPTION
Fixes atom/atom#6922. The squirrel will remain on the first launch after an upgrade, but will be gray instead of blue.

Right now, one of the tests is failing (second expect in `shows the view when the update is made available`, where it looks for the new class), but when I run manually it works as expected. Any pointers on how to correct the test configuration would be great!
